### PR TITLE
T-API python support implemented:

### DIFF
--- a/modules/java/generator/gen_java.py
+++ b/modules/java/generator/gen_java.py
@@ -1039,7 +1039,8 @@ class JavaWrapperGenerator(object):
         self.clear()
         self.module = module
         self.Module = module.capitalize()
-        parser = hdr_parser.CppHeaderParser()
+        # TODO: support UMat versions of declarations (implement UMat-wrapper for Java)
+        parser = hdr_parser.CppHeaderParser(generate_umat_decls=False)
 
         self.add_class( ['class ' + self.Module, '', [], []] ) # [ 'class/struct cname', ':bases', [modlist] [props] ]
 

--- a/modules/python/src2/gen2.py
+++ b/modules/python/src2/gen2.py
@@ -381,7 +381,8 @@ class ArgInfo(object):
         self.py_outputarg = False
 
     def isbig(self):
-        return self.tp == "Mat" or self.tp == "vector_Mat"# or self.tp.startswith("vector")
+        return self.tp == "Mat" or self.tp == "vector_Mat"\
+               or self.tp == "UMat" or self.tp == "vector_UMat" # or self.tp.startswith("vector")
 
     def crepr(self):
         return "ArgInfo(\"%s\", %d)" % (self.name, self.outputarg)
@@ -623,6 +624,10 @@ class FuncInfo(object):
                 defval = a.defval
                 if not defval:
                     defval = amapping[2]
+                else:
+                    if "UMat" in tp:
+                        if "Mat" in defval and "UMat" not in defval:
+                            defval = defval.replace("Mat", "UMat")
                 # "tp arg = tp();" is equivalent to "tp arg;" in the case of complex types
                 if defval == tp + "()" and amapping[1] == "O":
                     defval = ""
@@ -845,7 +850,7 @@ class PythonWrapperGenerator(object):
 
     def gen(self, srcfiles, output_path):
         self.clear()
-        self.parser = hdr_parser.CppHeaderParser()
+        self.parser = hdr_parser.CppHeaderParser(generate_umat_decls=True)
 
         # step 1: scan the headers and build more descriptive maps of classes, consts, functions
         for hdr in srcfiles:

--- a/modules/python/test/test.py
+++ b/modules/python/test/test.py
@@ -155,6 +155,60 @@ class Hackathon244Tests(NewOpenCVTests):
         boost.getMaxDepth() # from ml::DTrees
         boost.isClassifier() # from ml::StatModel
 
+    def test_umat_matching(self):
+        img1 = self.get_sample("samples/data/right01.jpg")
+        img2 = self.get_sample("samples/data/right02.jpg")
+
+        orb = cv2.ORB_create()
+
+        img1, img2 = cv2.UMat(img1), cv2.UMat(img2)
+        ps1, descs_umat1 = orb.detectAndCompute(img1, None)
+        ps2, descs_umat2 = orb.detectAndCompute(img2, None)
+
+        self.assertIsInstance(descs_umat1, cv2.UMat)
+        self.assertIsInstance(descs_umat2, cv2.UMat)
+        self.assertGreater(len(ps1), 0)
+        self.assertGreater(len(ps2), 0)
+
+        bf = cv2.BFMatcher(cv2.NORM_HAMMING, crossCheck=True)
+
+        res_umats = bf.match(descs_umat1, descs_umat2)
+        res = bf.match(descs_umat1.get(), descs_umat2.get())
+
+        self.assertGreater(len(res), 0)
+        self.assertEqual(len(res_umats), len(res))
+
+    def test_umat_optical_flow(self):
+        img1 = self.get_sample("samples/data/right01.jpg", cv2.IMREAD_GRAYSCALE)
+        img2 = self.get_sample("samples/data/right02.jpg", cv2.IMREAD_GRAYSCALE)
+        # Note, that if you want to see performance boost by OCL implementation - you need enough data
+        # For example you can increase maxCorners param to 10000 and increase img1 and img2 in such way:
+        # img = np.hstack([np.vstack([img] * 6)] * 6)
+
+        feature_params = dict(maxCorners=239,
+                              qualityLevel=0.3,
+                              minDistance=7,
+                              blockSize=7)
+
+        p0 = cv2.goodFeaturesToTrack(img1, mask=None, **feature_params)
+        p0_umat = cv2.goodFeaturesToTrack(cv2.UMat(img1), mask=None, **feature_params)
+        self.assertEqual(p0_umat.get().shape, p0.shape)
+
+        p0 = np.array(sorted(p0, key=lambda p: tuple(p[0])))
+        p0_umat = cv2.UMat(np.array(sorted(p0_umat.get(), key=lambda p: tuple(p[0]))))
+        self.assertTrue(np.allclose(p0_umat.get(), p0))
+
+        p1_mask_err = cv2.calcOpticalFlowPyrLK(img1, img2, p0, None)
+
+        p1_mask_err_umat0 = map(cv2.UMat.get, cv2.calcOpticalFlowPyrLK(img1, img2, p0_umat, None))
+        p1_mask_err_umat1 = map(cv2.UMat.get, cv2.calcOpticalFlowPyrLK(cv2.UMat(img1), img2, p0_umat, None))
+        p1_mask_err_umat2 = map(cv2.UMat.get, cv2.calcOpticalFlowPyrLK(img1, cv2.UMat(img2), p0_umat, None))
+
+        # # results of OCL optical flow differs from CPU implementation, so result can not be easily compared
+        # for p1_mask_err_umat in [p1_mask_err_umat0, p1_mask_err_umat1, p1_mask_err_umat2]:
+        #     for data, data_umat in zip(p1_mask_err, p1_mask_err_umat):
+        #         self.assertTrue(np.allclose(data, data_umat))
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='run OpenCV python tests')
     parser.add_argument('--repo', help='use sample image files from local git repository (path to folder), '


### PR DESCRIPTION
resolves #XXXX
### What does this PR change?

Please add your changes here.
- cv2.UMat implemented - python thin wrapper for UMat
- no implicit copy from GPU to Host done, resulting UMat can be passed to next function without overhead
- cv2.UMat.get() - to fetch data to Host
- new tests covers: ORB, BFMatcher, goodFeaturesToTrack, calcOpticalFlowPyrLK
